### PR TITLE
Enable to pass option for julia

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,8 @@ jobs:
       matrix:
         version:
           - '1.6'
-          #- 'nightly'
+          - '1.7'
+          - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/examples/quietmode/app.jl
+++ b/examples/quietmode/app.jl
@@ -1,0 +1,7 @@
+using Replay
+
+instructions = """
+println("julia -q")
+"""
+
+replay(instructions, cmd="-q")

--- a/test/references/replay_color_no_julia.txt
+++ b/test/references/replay_color_no_julia.txt
@@ -1,12 +1,3 @@
-               _
-   _       _ _(_)_     |  Documentation: https://docs.julialang.org
-  (_)     | (_) (_)    |
-   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
-  | | | | | | |/ _` |  |
-  | | |_| | | | (_| |  |  Version 1.6.4 (2021-11-19)
- _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
-|__/                   |
-
 [?2004h[0Kjulia> [7C[7C2+2[0Kjulia> [7C2+2[10C
 [?2004l4
 

--- a/test/references/replay_color_yes_julia.txt
+++ b/test/references/replay_color_yes_julia.txt
@@ -1,12 +1,3 @@
-               [1m[32m_[0m
-   [1m[34m_[0m       [0m_[0m [1m[31m_[1m[32m(_)[1m[35m_[0m     |  Documentation: https://docs.julialang.org
-  [1m[34m(_)[0m     | [1m[31m(_)[0m [1m[35m(_)[0m    |
-   [0m_ _   _| |_  __ _[0m   |  Type "?" for help, "]?" for Pkg help.
-  [0m| | | | | | |/ _` |[0m  |
-  [0m| | |_| | | | (_| |[0m  |  Version 1.6.4 (2021-11-19)
- [0m_/ |\__'_|_|_|\__'_|[0m  |  Official https://julialang.org/ release
-[0m|__/[0m                   |
-
 [?2004h[0K[32m[1mjulia> [0m[0m[7C[7C2+2[0K[32m[1mjulia> [0m[0m[7C2+2[10C
 [?2004l[0m[0m4
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,45 +10,32 @@ display([1])
 display([1 2; 3 4])
 """
 
-@testset "replay: color=yes" begin
-    buf = replay(repl_script, IOBuffer(), julia_project = "@.") # color=:yes by default
-    out = buf |> take! |> String
-    #=
-    open(joinpath(@__DIR__, "references", "replay_color_yes_julia_$VERSION.txt"), "w") do f
-        write(f, out)
+for color in [:yes, true]
+    @testset "replay: color=$color" begin
+        buf = replay(repl_script, IOBuffer(); color, cmd="-q")
+        out = buf |> take! |> String
+        #=
+        open(joinpath(@__DIR__, "references", "replay_color_$(color)_julia.txt"), "w") do f
+            write(f, out)
+        end
+        =#
+        reftxt = joinpath(@__DIR__, "references", "replay_color_yes_julia.txt")
+        ref = join(readlines(reftxt), "\r\n")
+        @test out == ref
     end
-    =#
-    reftxt = joinpath(@__DIR__, "references", "replay_color_yes_julia_$VERSION.txt")
-    ref = join(readlines(reftxt), "\r\n")
-    @test out == ref
 end
 
-@testset "replay: color=true" begin
-    buf = replay(repl_script, IOBuffer(), color = true)
-    out = buf |> take! |> String
-    reftxt = joinpath(@__DIR__, "references", "replay_color_yes_julia_$VERSION.txt")
-    ref = join(readlines(reftxt), "\r\n")
-    @test out == ref
-end
-
-@testset "replay: color=no" begin
-    buf = replay(repl_script, IOBuffer(), color = :no)
-    out = buf |> take! |> String
-
-    #=
-    open(joinpath(@__DIR__, "references", "replay_color_no_julia_$VERSION.txt"), "w") do f
-        write(f, out)
+for color in [:no, false]
+    @testset "replay: color=no" begin
+        buf = replay(repl_script, IOBuffer(), color = :no, cmd="-q")
+        out = buf |> take! |> String
+        #=
+        open(joinpath(@__DIR__, "references", "replay_color_$(color)_julia.txt"), "w") do f
+            write(f, out)
+        end
+        =#
+        reftxt = joinpath(@__DIR__, "references", "replay_color_no_julia.txt")
+        ref = join(readlines(reftxt), "\r\n")
+        @test out == ref
     end
-    =#
-    reftxt = joinpath(@__DIR__, "references", "replay_color_no_julia_$VERSION.txt")
-    ref = join(readlines(reftxt), "\r\n")
-    @test out == ref
-end
-
-@testset "replay: color=false" begin
-    buf = replay(repl_script, IOBuffer(), color = false)
-    out = buf |> take! |> String
-    reftxt = joinpath(@__DIR__, "references", "replay_color_no_julia_$VERSION.txt")
-    ref = join(readlines(reftxt), "\r\n")
-    @test out == ref
 end


### PR DESCRIPTION
This PR allows users to use keyword option named `cmd` 
e.g. `replay(instructions, cmd="-q")`