### PR TITLE
format code with `whitespace_in_kwargs=false`

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,2 @@
+whitespace_in_kwargs=false
+verbose=true

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,24 +1,19 @@
 using Replay
 using Documenter
 
-DocMeta.setdocmeta!(Replay, :DocTestSetup, :(using Replay); recursive = true)
+DocMeta.setdocmeta!(Replay, :DocTestSetup, :(using Replay); recursive=true)
 
 makedocs(;
-    modules = [Replay],
-    authors = "Satoshi Terasaki <terasakisatoshi.math@gmail.com> and contributors",
-    repo = "https://github.com/AtelierArith/Replay.jl/blob/{commit}{path}#{line}",
-    sitename = "Replay.jl",
-    format = Documenter.HTML(;
-        prettyurls = get(ENV, "CI", "false") == "true",
-        canonical = "https://AtelierArith.github.io/Replay.jl",
-        assets = String[]
+    modules=[Replay],
+    authors="Satoshi Terasaki <terasakisatoshi.math@gmail.com> and contributors",
+    repo="https://github.com/AtelierArith/Replay.jl/blob/{commit}{path}#{line}",
+    sitename="Replay.jl",
+    format=Documenter.HTML(;
+        prettyurls=get(ENV, "CI", "false") == "true",
+        canonical="https://AtelierArith.github.io/Replay.jl",
+        assets=String[],
     ),
-    pages = [
-        "Home" => "index.md",
-    ]
+    pages=["Home" => "index.md"],
 )
 
-deploydocs(;
-    repo = "github.com/AtelierArith/Replay.jl",
-    devbranch = "main"
-)
+deploydocs(; repo="github.com/AtelierArith/Replay.jl", devbranch="main")

--- a/examples/disable_color/app.jl
+++ b/examples/disable_color/app.jl
@@ -12,5 +12,5 @@ instructions = [
     """greet("Hello, World!")""",
 ]
 
-replay(instructions, use_ghostwriter = false, cmd = "--color=no")
-replay(instructions, use_ghostwriter = true, cmd = "--color=no")
+replay(instructions, use_ghostwriter=false, cmd="--color=no")
+replay(instructions, use_ghostwriter=true, cmd="--color=no")

--- a/examples/helloworld/app.jl
+++ b/examples/helloworld/app.jl
@@ -10,4 +10,4 @@ instructions = [
     """greet("Hello, World!")""",
 ]
 
-replay(instructions, use_ghostwriter = true)
+replay(instructions, use_ghostwriter=true)

--- a/examples/imageinterminal/app.jl
+++ b/examples/imageinterminal/app.jl
@@ -6,4 +6,4 @@ using ImageInTerminal
 testimage("mandril_color")
 """
 
-replay(instructions, julia_project = @__DIR__)
+replay(instructions, julia_project=@__DIR__)

--- a/examples/iris/app.jl
+++ b/examples/iris/app.jl
@@ -37,4 +37,4 @@ reduced_data = DataFrame(X * e.vectors[:, 1:topk], [:X, :Y]);
 @df reduced_data scatter(:X, :Y, group=iris.Species)
 """
 
-replay(instructions, use_ghostwriter = true, julia_project = @__DIR__)
+replay(instructions, use_ghostwriter=true, julia_project=@__DIR__)

--- a/examples/ohmyrepl/app.jl
+++ b/examples/ohmyrepl/app.jl
@@ -9,6 +9,6 @@ N = 10
 @show N
 """
 
-replay(instructions, use_ghostwriter = false, julia_project = @__DIR__)
+replay(instructions, use_ghostwriter=false, julia_project=@__DIR__)
 
-replay(instructions, use_ghostwriter = true, julia_project = @__DIR__)
+replay(instructions, use_ghostwriter=true, julia_project=@__DIR__)

--- a/examples/plots_with_sixel/app.jl
+++ b/examples/plots_with_sixel/app.jl
@@ -8,4 +8,4 @@ show(buf, MIME("image/png"), plot(sin, size=(1000, 750)))
 buf |> load |> sixel_encode
 """
 
-replay(instructions, julia_project = @__DIR__)
+replay(instructions, julia_project=@__DIR__)

--- a/examples/quietmode/app.jl
+++ b/examples/quietmode/app.jl
@@ -4,4 +4,4 @@ instructions = """
 println("julia -q")
 """
 
-replay(instructions, cmd = "-q")
+replay(instructions, cmd="-q")

--- a/examples/readme/app.jl
+++ b/examples/readme/app.jl
@@ -13,10 +13,4 @@ st
 $CTRL_C
 """
 
-replay(
-    repl_script,
-    stdout,
-    julia_project = @__DIR__,
-    use_ghostwriter = true,
-    cmd = "--color=yes",
-)
+replay(repl_script, stdout, julia_project=@__DIR__, use_ghostwriter=true, cmd="--color=yes")

--- a/examples/sixel/app.jl
+++ b/examples/sixel/app.jl
@@ -6,4 +6,4 @@ using Sixel
 sixel_encode(testimage("mandril_color"))
 """
 
-replay(instructions, julia_project = @__DIR__)
+replay(instructions, julia_project=@__DIR__)

--- a/examples/unicodefun/app.jl
+++ b/examples/unicodefun/app.jl
@@ -2,4 +2,4 @@ using Replay
 
 instructions = ["using UnicodeFun", "\"\\\\pi\" |> to_latex"]
 
-replay(instructions, julia_project = @__DIR__)
+replay(instructions, julia_project=@__DIR__)

--- a/examples/unicodeplots/app.jl
+++ b/examples/unicodeplots/app.jl
@@ -6,4 +6,4 @@ histogram(randn(1000) .* 0.1, nbins = 15, closed = :right, xscale=:log10)
 heatmap(collect(0:30) * collect(0:30)', xfact=0.1, yfact=0.1, xoffset=-1.5, colormap=:inferno)
 """
 
-replay(instructions, julia_project = @__DIR__)
+replay(instructions, julia_project=@__DIR__)

--- a/examples/unicodeplots_animated/app.jl
+++ b/examples/unicodeplots_animated/app.jl
@@ -38,4 +38,4 @@ instructions = [
     "animate(frames)",
 ]
 
-replay(instructions; julia_project = @__DIR__, use_ghostwriter = false)
+replay(instructions; julia_project=@__DIR__, use_ghostwriter=false)

--- a/examples/use_ghostwriter/app.jl
+++ b/examples/use_ghostwriter/app.jl
@@ -18,4 +18,4 @@ instructions = """
 "(Did we mention it should be as fast as C?))";
 """
 
-replay(instructions, use_ghostwriter = true)
+replay(instructions, use_ghostwriter=true)

--- a/src/FakePTYs.jl
+++ b/src/FakePTYs.jl
@@ -12,7 +12,7 @@ end
 function open_fake_pty()
     @static if Sys.iswindows()
         # Fake being cygwin
-        pid = string(getpid(), base = 16, pad = 16)
+        pid = string(getpid(), base=16, pad=16)
         pipename = """\\\\?\\pipe\\cygwin-$pid-pty10-abcdefg"""
         server = listen(pipename)
         pts = connect(pipename)

--- a/src/Replay.jl
+++ b/src/Replay.jl
@@ -14,7 +14,7 @@ const LEFT_ARROW = "\e[D"
 export CTRL_C, UP_ARROW, DOWN_ARROW, RIGHT_ARROW, LEFT_ARROW
 export replay
 
-function clearline(; move_up::Bool = false)
+function clearline(; move_up::Bool=false)
     buf = IOBuffer()
     print(buf, "\x1b[2K") # clear line
     print(buf, "\x1b[?25l") # hide cursor
@@ -25,11 +25,11 @@ end
 
 function clearlines(H::Integer)
     for _ = 1:H
-        clearline(move_up = true)
+        clearline(move_up=true)
     end
 end
 
-function type_with_ghost_core(line::AbstractString, mode; display_prompt = false)
+function type_with_ghost_core(line::AbstractString, mode; display_prompt=false)
     if !display_prompt
         # we assume we're in julian mode
         spacestring = " "
@@ -46,7 +46,7 @@ function type_with_ghost_core(line::AbstractString, mode; display_prompt = false
             end
         end
         println(join(line[begin:index]))
-        clearline(move_up = true)
+        clearline(move_up=true)
         duration = if 30 < length(line)
             0.0125
         elseif 15 < length(line) < 30
@@ -59,7 +59,7 @@ function type_with_ghost_core(line::AbstractString, mode; display_prompt = false
 end
 
 function type_with_ghost(repl_script::AbstractString, mode)
-    lines = split(String(repl_script), '\n'; keepempty = false)
+    lines = split(String(repl_script), '\n'; keepempty=false)
     H = length(lines)
     for (i, line) in enumerate(lines)
         display_prompt = (i == 1)
@@ -69,7 +69,7 @@ function type_with_ghost(repl_script::AbstractString, mode)
     clearlines(H)
 end
 
-function setup_pty(julia_project = "@."::AbstractString, cmd = String = "--color=yes")
+function setup_pty(julia_project="@."::AbstractString, cmd=String = "--color=yes")
     pts, ptm = open_fake_pty()
     blackhole = Sys.isunix() ? "/dev/null" : "nul"
     julia_exepath = joinpath(Sys.BINDIR, Base.julia_exename())
@@ -81,7 +81,13 @@ function setup_pty(julia_project = "@."::AbstractString, cmd = String = "--color
         # Install packages
         run(`$(julia_exepath) -e 'using Pkg; Pkg.instantiate()'`)
         # Initialize REPL
-        run(```$(julia_exepath) -i -e 'print("\x1b[?25l")' $(split(cmd))```, pts, pts, pts; wait = false)
+        run(
+            ```$(julia_exepath) -i -e 'print("\x1b[?25l")' $(split(cmd))```,
+            pts,
+            pts,
+            pts;
+            wait=false,
+        )
     end
     Base.close_stdio(pts)
     return replproc, ptm
@@ -89,10 +95,10 @@ end
 
 function replay(
     instructions::Vector{<:AbstractString},
-    buf::IO = stdout;
-    use_ghostwriter = false,
-    julia_project = "@.",
-    cmd = String = "--color=yes"
+    buf::IO=stdout;
+    use_ghostwriter=false,
+    julia_project="@.",
+    cmd=String = "--color=yes",
 )
     print("\x1b[?25l") # hide cursor
     replproc, ptm = setup_pty(julia_project, cmd)
@@ -194,7 +200,7 @@ function replay(
         if endswith(cell, CTRL_C)
             write(ptm, cell)
         else
-            if length(split(string(cell), '\n'; keepempty = false)) == 1
+            if length(split(string(cell), '\n'; keepempty=false)) == 1
                 write(ptm, cell, "\n")
             else
                 write(ptm, cell)
@@ -219,6 +225,6 @@ function replay(
 end
 
 replay(repl_script::AbstractString, args...; kwargs...) =
-    replay(split(String(repl_script), '\n'; keepempty = false), args...; kwargs...)
+    replay(split(String(repl_script), '\n'; keepempty=false), args...; kwargs...)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ println("Hello World")
 
 @testset "replay: color=yes" begin
     color = "yes"
-    buf = replay(repl_script, IOBuffer(); cmd = "-q --color=yes")
+    buf = replay(repl_script, IOBuffer(); cmd="-q --color=yes")
     out = buf |> take! |> String
     #=
     open(joinpath(@__DIR__, "references", "replay_color_$(color)_julia.txt"), "w") do f
@@ -23,7 +23,7 @@ end
 
 @testset "replay: color=no" begin
     color = "no"
-    buf = replay(repl_script, IOBuffer(); cmd = "-q --color=no")
+    buf = replay(repl_script, IOBuffer(); cmd="-q --color=no")
     out = buf |> take! |> String
     #=
     open(joinpath(@__DIR__, "references", "replay_color_$(color)_julia.txt"), "w") do f


### PR DESCRIPTION
I would like to disable `whitespace_in_kwargs` functionality of [JuliaFormatter](https://github.com/domluna/JuliaFormatter.jl#whitespace_in_kwargs) which is compatible with `black` style that I prefer to apply against Python code.
