### PR TITLE
Tab completion

### DIFF
--- a/examples/tab_completion/app.jl
+++ b/examples/tab_completion/app.jl
@@ -1,0 +1,17 @@
+using Replay
+
+instructions = [
+    """\"\"\"
+    The tab key can also be used to substitute
+    LaTeX math symbols with their Unicode equivalents, 
+    and get a list of LaTeX matches as well:
+    \"\"\";
+    """,
+    "# Example:",
+    "# \\sigma\\<TAB> で σ が出るよ.",
+    "# <TAB> はタブキーを入力すると解釈してね",
+    "# \\sigma<TAB>\\_i<TAB>\\^(j-1)<TAB> = 1 で",
+    "# σᵢ⁽ʲ⁻¹⁾ = 1 が出るよ",
+    "\\sigma$(TAB)\\_i$(TAB)\\^(j-1)$(TAB) = 1"
+]
+replay(instructions, use_ghostwriter=true)

--- a/examples/tab_completion/app.jl
+++ b/examples/tab_completion/app.jl
@@ -12,6 +12,6 @@ instructions = [
     "# <TAB> はタブキーを入力すると解釈してね",
     "# \\sigma<TAB>\\_i<TAB>\\^(j-1)<TAB> = 1 で",
     "# σᵢ⁽ʲ⁻¹⁾ = 1 が出るよ",
-    "\\sigma$(TAB)\\_i$(TAB)\\^(j-1)$(TAB) = 1"
+    "\\sigma$(TAB)\\_i$(TAB)\\^(j-1)$(TAB) = 1",
 ]
 replay(instructions, use_ghostwriter=true)

--- a/src/Replay.jl
+++ b/src/Replay.jl
@@ -6,12 +6,14 @@ include("FakePTYs.jl")
 using .FakePTYs: open_fake_pty
 
 const CTRL_C = "\x03"
+const TAB = "\t"
 const UP_ARROW = "\e[A"
 const DOWN_ARROW = "\e[B"
 const RIGHT_ARROW = "\e[C"
 const LEFT_ARROW = "\e[D"
 
-export CTRL_C, UP_ARROW, DOWN_ARROW, RIGHT_ARROW, LEFT_ARROW
+export CTRL_C, TAB
+export UP_ARROW, DOWN_ARROW, RIGHT_ARROW, LEFT_ARROW
 export replay
 
 function clearline(; move_up::Bool=false)


### PR DESCRIPTION
Example using TAB key `\t` is added.
It also exports `TAB` variable
