### PR TITLE
Fix exit non-julian modes

### DIFF
--- a/examples/pkgmode/app.jl
+++ b/examples/pkgmode/app.jl
@@ -2,8 +2,7 @@ using Replay
 
 instructions = [
     "# Pkg mode",
-    "] st",
-    CTRL_C,
+    "]st",
 ]
 
 replay(instructions, use_ghostwriter=true)

--- a/src/Replay.jl
+++ b/src/Replay.jl
@@ -217,7 +217,11 @@ function replay(
 
     sleep(1)
     use_ghostwriter && type_with_ghost("exit()", mode)
-    write(ptm, "exit()\n")
+    if current_mode_name === :julian
+        write(ptm, "exit()\n")
+    else
+        write(ptm, "\bexit()\n")
+    end
     sleep(1)
     wait(tee)
     success(replproc) || Base.pipeline_error(replproc)


### PR DESCRIPTION
This PR adds `\b` to break the non-julian modes, and fix #53.

**Before this PR**
[![asciicast](https://asciinema.org/a/aYroAIk77shy3s0Zm3vd8BsnK.png)](https://asciinema.org/a/aYroAIk77shy3s0Zm3vd8BsnK)

**After this PR**
[![asciicast](https://asciinema.org/a/qGUcovHDmXL2pSgBUiW0uu0xF.png)](https://asciinema.org/a/qGUcovHDmXL2pSgBUiW0uu0xF)

Note that this fix is a little dirty because it shows `(Replay) pkg> exit()` during the inputs.