### PR TITLE
Add docstring to `replay` funciton

### DIFF
--- a/src/Replay.jl
+++ b/src/Replay.jl
@@ -71,7 +71,7 @@ function type_with_ghost(repl_script::AbstractString, mode)
     clearlines(H)
 end
 
-function setup_pty(julia_project="@."::AbstractString, cmd=String = "--color=yes")
+function setup_pty(julia_project="@."::AbstractString, cmd="--color=yes")
     pts, ptm = open_fake_pty()
     blackhole = Sys.isunix() ? "/dev/null" : "nul"
     julia_exepath = joinpath(Sys.BINDIR, Base.julia_exename())
@@ -115,7 +115,7 @@ function replay(
     buf::IO=stdout;
     use_ghostwriter=false,
     julia_project="@.",
-    cmd=String = "--color=yes",
+    cmd="--color=yes",
 )
     print("\x1b[?25l") # hide cursor
     replproc, ptm = setup_pty(julia_project, cmd)

--- a/src/Replay.jl
+++ b/src/Replay.jl
@@ -95,6 +95,21 @@ function setup_pty(julia_project="@."::AbstractString, cmd=String = "--color=yes
     return replproc, ptm
 end
 
+"""
+    replay(instructions::Vector{<:AbstractString}, buf::IO; kwargs...)
+
+Replay the REPL output from given instructions.
+
+## Keyword Arguments
+
+### Replay options
+- `use_ghostwriter`: Flag to enable ghostwriter mode. (default: `true`)
+
+### Julia options
+- `julia_project`: Path to a project where julia process runs. (default: `@.`)
+- `cmd`: Additional command for julia process. (default: `"--color=yes"`)
+
+"""
 function replay(
     instructions::Vector{<:AbstractString},
     buf::IO=stdout;


### PR DESCRIPTION
This PR adds a docstring to `replay` function. I used [`PkgTemplates.Template`](https://github.com/JuliaCI/PkgTemplates.jl/blob/47aa85f0247dc5d2a695f97efcc245c37e414325/src/template.jl#L33-L60) as a reference for the format of the docstring.